### PR TITLE
Fix pg_wait_sampling compilation instruction

### DIFF
--- a/docs/components/stats_extensions/pg_wait_sampling.rst
+++ b/docs/components/stats_extensions/pg_wait_sampling.rst
@@ -53,13 +53,13 @@ Then, compile the extension:
 
 .. code-block:: bash
 
-  make
+  make USE_PGXS=1
 
 Then install the compiled package:
 
 .. code-block:: bash
 
-  make install
+  make USE_PGXS=1 install
 
 Then you just have to declare the extension in the ``postgresql.conf`` file, like this :
 


### PR DESCRIPTION
Without the `USE_PGXS=1` option the compilation fails:
```
Makefile:24: /contrib/contrib-global.mk: No such file or directory
make: *** No rule to make target '/contrib/contrib-global.mk'.  Stop.
```
https://github.com/postgrespro/pg_wait_sampling/#installation