### PR TITLE
Difference between creating and preloading the extension in a remote setup

### DIFF
--- a/docs/components/powa-archivist/installation.rst
+++ b/docs/components/powa-archivist/installation.rst
@@ -98,9 +98,8 @@ Example:
   powa=# create extension powa;
   CREATE EXTENSION
 
-
-As PoWA-archivist is implemented as a background worker, the library must be
-loaded at server start time.
+As PoWA-archivist can provide a background worker, the library must be loaded
+at server start time if local metric collection is wanted.
 
 For this, modify the ``postgresql.conf`` configuration file, and add powa and
 pg_stat_statements to the ``shared_preload_libraries`` parameter:

--- a/docs/components/powa-archivist/installation.rst
+++ b/docs/components/powa-archivist/installation.rst
@@ -3,6 +3,17 @@
 Installation
 ************
 
+Introduction
+------------
+
+PoWA-archivist is the core component of the PoWA project. It is composed of 2
+elements:
+
+* an extension named "powa" containing management functions
+* a module name "powa" that runs a background worker collecting the
+  performance metadata
+
+
 Prerequisites
 -------------
 

--- a/docs/remote_setup.rst
+++ b/docs/remote_setup.rst
@@ -51,7 +51,7 @@ instance restart is not required anymore.
 Configure PoWA and stats extensions on each remote server
 *********************************************************
 
-You need to install configure :ref:`powa_archivist` and the
+You need to install and configure :ref:`powa_archivist` and the
 :ref:`stat_extensions` of your choice on each remote PostgreSQL server.
 
 Declare the list of remote servers and their extensions

--- a/docs/remote_setup.rst
+++ b/docs/remote_setup.rst
@@ -51,8 +51,8 @@ instance restart is not required anymore.
 Configure PoWA and stats extensions on each remote server
 *********************************************************
 
-You need to configure :ref:`powa_archivist` and the :ref:`stat_extensions` of
-your choice on each remote PostgreSQL server.
+You need to install configure :ref:`powa_archivist` and the
+:ref:`stat_extensions` of your choice on each remote PostgreSQL server.
 
 Declare the list of remote servers and their extensions
 *******************************************************


### PR DESCRIPTION

Following our discussion, here's a small patch to clarify the difference between preloading and creating the powa extension inside the distant servers when deploying a remote collection setup.



