### PR TITLE
Remove -readthedocs-sphinx-search

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
-readthedocs-sphinx-search
 requests
 sphinxcontrib-domaintools
 sphinxcontrib-napoleon
-sphinx_rtd_theme
+sphinx_rtd_theme>=3.0.0
 sphinx-tabs
 sphinx-autobuild


### PR DESCRIPTION
I would have thought that readthedocs would be good at documenting things but they're actually terrible.  Their main documentation still point to it but the git repository of that module says that it's deprecated and shouldn't be used anymore.  It didn't fix anything so let's just remove it.  Try to force the main rtd theme to be 3.x just in case this fixes the search.